### PR TITLE
Support for any repo +  remote exec

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -10,6 +10,7 @@ const mutex = new Mutex();
 var shell = require('shelljs');
 
 var libCollector = require("./collector");
+const {benchRepo} = require("./src/bench-repo");
 
 function BenchContext(app, config) {
     var self = this;
@@ -22,7 +23,7 @@ function BenchContext(app, config) {
         const { stdout, stderr, code } = shell.exec(cmd, { silent: true });
         var error = false;
 
-        if (code != 0) {
+        if (code !== 0) {
             app.log(`ops.. Something went wrong (error code ${code})`);
             app.log(`stderr: ${stderr}`);
             error = true;
@@ -75,7 +76,7 @@ async function benchBranch(app, config) {
         collector = new libCollector.Collector();
 
         var benchContext = new BenchContext(app, config);
-        console.log(`Started benchmark "${benchConfig.title}."`);
+        app.log(`Started benchmark "${benchConfig.title}."`);
         shell.mkdir("git")
         shell.cd(cwd + "/git")
 
@@ -295,7 +296,8 @@ async function benchmarkRuntime(app, config) {
         } else if (config.repo == "polkadot") {
             benchConfig = PolkadotRuntimeBenchmarkConfigs[command];
         } else {
-            return errorResult(`${config.repo} repo is not supported.`)
+            app.log(`custom repo ${config.repo}`)
+            return benchRepo(app, config)
         }
 
         var extra = config.extra.split(" ").slice(1).join(" ").trim();
@@ -326,7 +328,7 @@ async function benchmarkRuntime(app, config) {
         }
 
         var benchContext = new BenchContext(app, config);
-        console.log(`Started runtime benchmark "${benchConfig.title}."`);
+        app.log(`Started runtime benchmark "${benchConfig.title}."`);
         shell.mkdir("git")
         shell.cd(cwd + "/git")
 

--- a/src/bench-context.js
+++ b/src/bench-context.js
@@ -1,0 +1,53 @@
+
+const shell = require('shelljs');
+
+function escq (cmd) {
+  const escaped = String.prototype.replace.call(cmd, /'/gm, "'\\''");
+  return `'${escaped}'`;
+}
+
+function BenchContext(app, config) {
+    let self = this;
+    self.app = app;
+    self.config = config;
+
+    self.temp_dir = process.env.BENCH_TEMP_DIR || 'git';
+
+    self.createTempDir = function (){
+        let cmd = `mkdir -p ${self.temp_dir}`
+        self.runTask(cmd, `Creating temp working dir ${self.temp_dir}`, false);
+    }
+
+    self.runTask = function(cmd, title, in_temp_dir=true) {
+        if (title) app.log(title);
+
+        let cmds = in_temp_dir ? `cd ${self.temp_dir} && ${cmd}` : `${cmd}`;
+
+        let cmdString = self.remoteWrapper(cmds);
+
+        const { stdout, stderr, code } = shell.exec(cmdString, { silent: true });
+        let error = false;
+
+        if (code !== 0) {
+            app.log(`ops.. Something went wrong (error code ${code})`);
+            app.log(`stderr: ${stderr}`);
+            error = true;
+        }
+
+        return { stdout, stderr, error };
+    }
+
+    self.remoteWrapper = function(cmd){
+        if (self.config.remote !== undefined) {
+            let { host, user} = config.remote;
+
+            let domain = `${user}@${host}`;
+            return `ssh ${domain} ${escq(cmd)}`;
+        }
+        return cmd;
+    }
+}
+
+module.exports = {
+    BenchContext: BenchContext
+}

--- a/src/bench-helpers.js
+++ b/src/bench-helpers.js
@@ -1,0 +1,33 @@
+function errorResult(stderr, step) {
+    return { error: true, step, stderr }
+}
+
+function checkAllowedCharacters(command) {
+    let banned = ["#", "&", "|", ";"];
+    for (const token of banned) {
+        if (command.includes(token)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function checkRuntimeBenchmarkCommand(command) {
+    let required = ["benchmark", "--pallet", "--extrinsic", "--execution", "--wasm-execution", "--steps", "--repeat", "--chain"];
+    let missing = [];
+    for (const flag of required) {
+        if (!command.includes(flag)) {
+            missing.push(flag);
+        }
+    }
+
+    return missing;
+}
+
+module.exports = {
+    errorResult: errorResult,
+    checkAllowedCharacters: checkAllowedCharacters,
+    checkRuntimeBenchmarkCommand: checkRuntimeBenchmarkCommand
+}
+
+

--- a/src/bench-repo.js
+++ b/src/bench-repo.js
@@ -1,0 +1,170 @@
+const {BenchContext} = require("./bench-context");
+const {checkRuntimeBenchmarkCommand} = require("./bench-helpers");
+const {errorResult, checkAllowedCharacters} = require("./bench-helpers");
+
+const CustomRuntimeBenchmarkConfigs = {
+    "pallet": {
+        title: "Benchmark Runtime Pallet",
+        branchCommand: [
+            'cargo run --release',
+            '--features=runtime-benchmarks',
+            '--manifest-path={manifest_path}',
+            '--',
+            'benchmark',
+            '--chain=dev',
+            '--steps=50',
+            '--repeat=20',
+            '--pallet={pallet_name}',
+            '--extrinsic="*"',
+            '--execution=wasm',
+            '--wasm-execution=compiled',
+            '--heap-pages=4096',
+            '--output={bench_output}',
+            '--template={hbs_template}',
+        ].join(' '),
+    },
+}
+
+function getManifestPath(){
+    return process.env.MANIFEST_PATH || 'node/Cargo.toml';
+}
+
+function getOutputTemplate(){
+    return process.env.BENCH_PALLET_OUTPUT_FILE || 'weights.rs';
+}
+
+function getHBSTemplate(){
+    return process.env.BENCH_PALLET_HBS_TEMPLATE || '.maintain/pallet-weight-template.hbs';
+}
+
+async function benchRepo(app, config){
+    let command = config.extra.split(" ")[0];
+
+    const supported_commands = Object.keys(CustomRuntimeBenchmarkConfigs);
+
+    if (!supported_commands.includes(command)){
+        return errorResult(`${command} is not supported command`)
+    }
+
+    let pallet_name = config.extra.split(" ").slice(1).join(" ").trim();
+
+    if (!checkAllowedCharacters(pallet_name)) {
+        return errorResult(`Not allowed to use #&|; in the command!`);
+    }
+
+    let manifest_path = getManifestPath();
+    let bench_output = getOutputTemplate();
+    let hbs_template = getHBSTemplate();
+
+    let commandConfig = CustomRuntimeBenchmarkConfigs[command];
+
+    let cargoCommand = commandConfig.branchCommand;
+
+    cargoCommand = cargoCommand.replace("{manifest_path}", manifest_path);
+    cargoCommand = cargoCommand.replace("{bench_output}", bench_output);
+    cargoCommand = cargoCommand.replace("{hbs_template}", hbs_template);
+    cargoCommand = cargoCommand.replace("{pallet_name}", pallet_name);
+
+    let missing = checkRuntimeBenchmarkCommand(cargoCommand);
+
+    if (missing.length > 0) {
+        return errorResult(`Missing required flags: ${missing.toString()}`)
+    }
+
+    config["title"] = commandConfig.title;
+
+    let benchContext = new BenchContext(app, config);
+
+    benchContext.pallet_name = pallet_name;
+    benchContext.bench_output = bench_output;
+
+    return runBench(cargoCommand, benchContext);
+}
+
+async function clone_and_sync(context){
+    let github_repo = `https://github.com/${context.config.owner}/${context.config.repo}`;
+
+    var {error} = context.runTask(`git clone ${github_repo} ${context.temp_dir}`, `Cloning git repository ${github_repo} ...`, false);
+
+    if (error) {
+        context.app.log("Git clone failed, probably directory exists...");
+    }
+
+    var { stderr, error } = context.runTask(`git fetch`, "Doing git fetch...");
+
+   if (error) return errorResult(stderr);
+
+    // Checkout the custom branch
+    var { error } = context.runTask(`git checkout ${context.config.branch}`, `Checking out ${context.config.branch}...`);
+
+    if (error) {
+        context.app.log("Git checkout failed, probably some dirt in directory... Will continue with git reset.");
+    }
+
+    var { error, stderr } = context.runTask(`git reset --hard origin/${context.config.branch}`, `Resetting ${context.config.branch} hard...`);
+    if (error) return errorResult(stderr);
+
+    // Merge master branch
+    var { error, stderr } = context.runTask(`git merge origin/${context.config.baseBranch}`, `Merging branch ${context.config.baseBranch}`);
+
+    if (error) return errorResult(stderr, "merge");
+
+    if (context.config.pushToken) {
+        context.runTask(`git push https://${context.config.pushToken}@github.com/${context.config.owner}/${context.config.repo}.git HEAD`, `Pushing merge with pushToken.`);
+    } else {
+        context.runTask(`git push`, `Pushing merge.`);
+    }
+
+    return true;
+}
+
+async function runBench(command, context){
+    context.app.log(`Started runtime benchmark "${context.config.title}."`);
+
+    // If there is a preparation command - run it first
+    context.config.preparationCommand && context.runTask(context.config.preparationCommand, "Preparation command", false);
+
+    context.createTempDir();
+
+    let git_result = await clone_and_sync(context);
+
+    if (git_result.error){
+        return git_result;
+    }
+
+    let { stdout, stderr, error } = context.runTask(command, `Benching branch: ${context.config.branch}...`);
+
+    if (error){
+        return errorResult(stderr, 'benchmark')
+    }
+
+    let output = command.includes("--output");
+
+    // If `--output` is set, we commit the benchmark file to the repo
+    if (output) {
+        let palletFolder = context.pallet_name.split('_').join('-').trim();
+        let weightsPath = `pallets/${palletFolder}/src/weights.rs`;
+        let cmd = `mv ${context.bench_output} ${weightsPath}`;
+
+        context.runTask(cmd);
+
+        context.runTask(`git add ${weightsPath}`, `Adding new files.`);
+        context.runTask(`git commit -m "Weights update for ${context.pallet_name} pallet"`, `Committing changes.`);
+
+        if (config.pushToken) {
+            context.runTask(`git push https://${context.config.pushToken}@github.com/${context.config.owner}/${context.config.repo}.git HEAD`, `Pushing commit with pushToken.`);
+        } else {
+            context.runTask(`git push origin ${context.config.branch}`, `Pushing commit.`);
+        }
+    }
+
+    return `Benchmark: **${context.config.title}**\n\n`
+        + command
+        + "\n\n<details>\n<summary>Results</summary>\n\n"
+        + (stdout ? stdout : stderr)
+        + "\n\n </details>";
+}
+
+module.exports = {
+    benchRepo : benchRepo
+}

--- a/src/env.template
+++ b/src/env.template
@@ -1,0 +1,19 @@
+WEBHOOK_PROXY_URL=https://smee.io/c3QrFmKxYuLn1jx
+
+# Github APP
+APP_ID=""
+PRIVATE_KEY_PATH=""
+WEBHOOK_SECRET=""
+BASE_BRANCH="main"
+
+# Cargo command options to replace with
+MANIFEST_PATH="node/Cargo.toml"
+BENCH_PALLET_OUTPUT_FILE="weights.rs"
+BENCH_PALLET_HBS_TEMPLATE=".maintain/pallet-weight-template.hbs"
+
+# Directory which repository is cloned into
+BENCH_TEMP_DIR="git"
+
+# Remote support - if specified - all commands are executed on the remote machine instead locally
+#REMOTE_HOST=""
+#REMOTE_USER=""


### PR DESCRIPTION
Hi,

In HydraDX, we liked the bench-bot and wanted to use it in similar way it is done in substrate/polkadot repository.

However , it needed some adjustments so it could be used with our Substrate project.

And instead of just hacking the bench-bot to fit our project - we thought to make changes in a way that the bench-bot can be used with any other substrate project which follows standard Substrate template node repository. 

It might be beneficial for other substrate projects. 

So within this PR, we added handling of other than substrate and polkadot repositories. 

Currently, it is all done separately to keep the benchmarking process for substrate/polkadot  intact as it is slightly differs in  few things. And it should fit any project which uses substrate template node as a template.

It is actually still work in progress ( hence the draft pr) - I am still adding few improvements. 

And I also want to add some features like whitelisted users and cancel benchmarks -  which I saw too in  Bench-bot v2 spec created by @shawntabrizi    ( but that might be done separately ).

But i thought why not just to create PR to propose and ask you for opinions. 

We also needed to run the benchmarks on specific machine , so there is also implemented a possibility to run all commands on a remote machine by specifying remote host/user. 

