### PR TITLE
Only allowed users can execute benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ WEBHOOK_PROXY_URL=<web hook url (like https://smee.io), not required>
 
 Add `BASE_BRANCH=master` or whatever is appropriate.
 
+#### Allowed users
+
+It is possible to restrict who can execute a benchmark. 
+
+Add `ALLOWED_USERS` with comma separated list of user's github ids. Eg: 
+
+`ALLOWED_USERS=123,455,234`
+
+Github user id can be retrieved using Github API: https://api.github.com/users/your_github_user_name
+
+If `ALLOWD_USERS` is not specified - any user can execute the benchmark.
+
 ## Permissions Needed
 
 * Metadata: Read Only

--- a/index.js
+++ b/index.js
@@ -1,5 +1,15 @@
 
-var { benchBranch, benchmarkRuntime } = require("./bench");
+const { benchBranch, benchmarkRuntime } = require("./bench");
+
+let allowedUsers = process.env.ALLOWED_USERS;
+if (allowedUsers) {
+  allowedUsers = allowedUsers.split(",").map(Number).filter(item => item);
+}
+
+// Allow only selected users or if not specified - allow any.
+function isAllowed(senderId) {
+  return allowedUsers === undefined || allowedUsers.includes(senderId);
+}
 
 module.exports = app => {
   app.log(`base branch: ${process.env.BASE_BRANCH}`);
@@ -7,6 +17,18 @@ module.exports = app => {
   app.on('issue_comment', async context => {
     let commentText = context.payload.comment.body;
     if (!commentText.startsWith("/bench")) {
+      return;
+    }
+
+    if (! isAllowed(context.payload.sender.id)){
+      app.log(`User not allowed ${context.payload.sender.id}`)
+      const repo = context.payload.repository.name;
+      const owner = context.payload.repository.owner.login;
+      const comment_id = context.payload.comment.id;
+      context.github.issues.updateComment({
+        owner, repo, comment_id,
+        body: `Denied. User is not allowed to execute benchmark.`
+      });
       return;
     }
 


### PR DESCRIPTION
Added a configurable option to allow only selected users to execute benchmarks.

It is done via ALLOWED_USERS env - details are in README.

If not provided - any user is allowed (original behavior).