### PR TITLE
Tweak dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        # Ignore minor/patch upgrades; only bother with opening the upgrade PR
+        # when a new major release comes out; security updates are nevertheless
+        # unaffected by this setting and will continue to work.
+        update-types: ["version-update:semver-patch","version-update:semver-minor"]


### PR DESCRIPTION
Make it only create the PRs when it's wortwhile to do so (major releases and security fixes)