### PR TITLE
Tweak package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,12 @@
 {
   "name": "bench-bot",
-  "version": "1.0.0",
-  "private": true,
-  "description": "Benchmarking bot",
-  "author": "NikVolf <nikvolf@gmail.com>",
+  "version": "0.0.0",
+  "description": "bench-bot",
+  "author": "Parity <admin@parity.io>",
   "license": "ISC",
-  "repository": "https://github.com/NikVolf/bench-bot.git",
-  "homepage": "https://github.com/NikVolf/bench-bot",
-  "bugs": "https://github.com/NikVolf/bench-bot/issues",
-  "keywords": [
-    "probot",
-    "github",
-    "probot-app"
-  ],
+  "repository": "https://github.com/paritytech/bench-bot",
+  "homepage": "https://github.com/paritytech/bench-bot",
+  "bugs": "https://github.com/paritytech/bench-bot/issues",
   "scripts": {
     "dev": "nodemon",
     "start": "probot run ./index.js",
@@ -22,26 +16,12 @@
   },
   "dependencies": {
     "async-mutex": "^0.1.4",
-    "dotenv": "^8.2.0",
-    "mocha": "^7.1.0",
-    "neat-csv": "^5.2.0",
     "probot": "^10.8.0",
     "shelljs": "^0.8.3"
   },
   "devDependencies": {
     "jest": "^24.9.0",
-    "nock": "^11.4.0",
-    "nodemon": "^2.0.0",
-    "smee-client": "^1.1.0",
-    "standard": "^14.3.1"
-  },
-  "engines": {
-    "node": ">= 8.3.0"
-  },
-  "standard": {
-    "env": [
-      "jest"
-    ]
+    "nodemon": "^2.0.0"
   },
   "nodemonConfig": {
     "exec": "npm start",


### PR DESCRIPTION
dependabot is opening lots of PRs for useless dependencies e.g. https://github.com/paritytech/bench-bot/pull/29

This PR prevents that by removing unneded dependencies and cleaning up package.json

- `smee-client` and `.env` are already included by Probot
- Tests are not useful at the moment so there's no need to include those dependencies