### PR TITLE
Truncate Long Report

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const fs = require("fs")
 var { benchBranch, benchmarkRuntime } = require("./bench");
 
 module.exports = app => {
-  const baseBranch = process.env.BASE_BRANCH || "master" 
+  const baseBranch = process.env.BASE_BRANCH || "master"
   app.log(`base branch: ${baseBranch}`);
 
   const appId = parseInt(process.env.APP_ID)
@@ -92,6 +92,9 @@ module.exports = app => {
     } else {
       report = await benchBranch(app, config)
     };
+
+    // Max github body is 65536 characters... we are a little conservative.
+    report = report.substring(0, 65000)
 
     if (report.error) {
       app.log(`error: ${report.stderr}`)


### PR DESCRIPTION
Github message body has a maximum of 65536:

```
(node:1265884) UnhandledPromiseRejectionWarning: HttpError: Validation Failed: {"resource":"IssueComment","code":"custom","field":"body","message":"body is too long (maximum is 65536 characters)"}
    at /home/benchbot/bench-bot/node_modules/@octokit/request/dist-node/index.js:68:23
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async sendRequestWithRetries (/home/benchbot/bench-bot/node_modules/@octokit/auth-app/dist-node/index.js:450:12)
    at async Job.doExecute (/home/benchbot/bench-bot/node_modules/bottleneck/light.js:405:18)
(node:1265884) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 3)
(node:1265884) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```