### PR TITLE
Decrease command execution overhead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules
 *.pem
 .env
 git
-log.txt
+runner_stdout.txt

--- a/README.md
+++ b/README.md
@@ -88,8 +88,6 @@ After it's running, the logs will be to the systemd journal:
 
 `sudo journalctl -u benchbot.service`
 
-As well as to `./log.txt`.
-
 # Github Settings
 
 ## Permissions

--- a/bench.js
+++ b/bench.js
@@ -33,7 +33,7 @@ function BenchContext(app, config) {
       try {
         if (shouldLogOutput) {
           console.log(`<=== Start command output (cwd: ${process.cwd()})`)
-          cp.execFileSync("/bin/dash", ["-c", `${cmd} | tee ${runnerOutput}`], { stdio: "ignore" })
+          cp.execFileSync("/bin/dash", ["-c", cmd], { stdio: "ignore" })
           stdout = fs.readFileSync(runnerOutput).toString()
         } else {
           stdout = cp.execSync(cmd, { stdio: "pipe", shell: true }).toString()
@@ -42,8 +42,6 @@ function BenchContext(app, config) {
         error = true
         if (err.code) {
           app.log(`Command ${cmd} failed with error code ${error.code}`);
-          stdout = err.stdout.toString()
-
           stderr = err.stderr.toString()
           if (stderr) {
             app.log(`stderr: ${stderr.trim()}`);

--- a/bench.js
+++ b/bench.js
@@ -33,7 +33,7 @@ function BenchContext(app, config) {
       try {
         if (shouldLogOutput) {
           console.log(`<=== Start command output (cwd: ${process.cwd()})`)
-          cp.execFileSync("/bin/dash", ["-c", `${cmd} | tee ${runnerOutput}`], { stdio: "inherit" })
+          cp.execFileSync("/bin/dash", ["-c", `${cmd} | tee ${runnerOutput}`], { stdio: "ignore" })
           stdout = fs.readFileSync(runnerOutput).toString()
         } else {
           stdout = cp.execSync(cmd, { stdio: "pipe", shell: true }).toString()

--- a/bench.js
+++ b/bench.js
@@ -28,32 +28,13 @@ function BenchContext(app, config) {
         app.log(title)
       }
 
-      let stdout = "", stderr = "", error = false
+      const { stdout, stderr, code } = shell.exec(cmd, { silent: !shouldLogOutput });
+      var error = false
 
-      try {
-        if (shouldLogOutput) {
-          console.log(`<=== Start command output (cwd: ${process.cwd()})`)
-          cp.execFileSync("/bin/dash", ["-c", cmd], { stdio: "ignore" })
-          stdout = fs.readFileSync(runnerOutput).toString()
-        } else {
-          stdout = cp.execSync(cmd, { stdio: "pipe", shell: true }).toString()
-        }
-      } catch (err) {
+      if (code != 0) {
+        app.log(`Command failed with error code ${code}: ${cmd}`)
+        console.log(stderr)
         error = true
-        if (err.code) {
-          app.log(`Command ${cmd} failed with error code ${error.code}`);
-          stderr = err.stderr.toString()
-          if (stderr) {
-            app.log(`stderr: ${stderr.trim()}`);
-          }
-        } else {
-          app.log.error("Caught exception in command execution")
-          app.log.error(err)
-        }
-      } finally {
-        if (shouldLogOutput) {
-          console.log("===> Finished command output")
-        }
       }
 
       return { stdout, stderr, error };

--- a/run
+++ b/run
@@ -139,7 +139,7 @@ main() {
   source ~/.cargo/env && \
   cd "$install_location" && \
   yarn && \
-  yarn start 2>&1 | tee -a log.txt
+  yarn start 2>&1
 }
 
 follow_service_logs() {


### PR DESCRIPTION
In https://github.com/paritytech/bench-bot/pull/46 I had introduced output streaming so that the commands' outputs could be seen in the log; this is useful for following the progress of a given command. In that PR I switched away from shelljs' execution because it was throwing nonsensical errors related to temporary files. The execution was refactored to use `spawnSync` which seemingly adds a lot of overhead to the commands ([this issue](https://github.com/nodejs/node/issues/3429) could to be related).

shelljs seems to perform much better than `spawnSync`; however, we would like to have a way of streaming the output into the logs without hindering performance. How to have both?

**1.** From the [shelljs source](https://github.com/shelljs/shelljs/blob/79ae14d30d7ce4064de05d41c7889885326b6754/src/exec.js#L83) we can see that they're using `execFileSync` which apparently performs much better; through this PR we'll execute the commands the same way.
**2.** To avoid having Node.js process the commands' streams we'll use `stdio: "inherit"` which will forward them to the parent process (i.e. they'll be output to the console, therefore showing up in the logs).
**3.** Since streams are not captured according to **2.** but we still want to collect stdout for parsing the benchmarks' results, the output is redirected to a file with `tee` and then read after the command finishes.