### PR TITLE
Decrease overhead take 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ node_modules
 *.pem
 .env
 git
-log.txt

--- a/run
+++ b/run
@@ -114,13 +114,15 @@ install_deps() {
     curl https://sh.rustup.rs -sSf | sh -s -- -y
     exit_if_error "Failed to install rustup"
 
-    rustup toolchain nightly
+    # For ensuring consistency, it's _required_ that the default toolchain is
+    # the same that the release team's Substrate benchmark scripts for Substrate
+    # uses. It's _good_ to have the toolchain's versions also match.
+    rustup default stable
+
+    rustup toolchain install nightly
     exit_if_error "Failed to install nightly toolchain"
 
-    rustup default nightly
-    exit_if_error "Failed to set up nightly toolchain"
-
-    rustup target add wasm32-unknown-unknown
+    rustup target add wasm32-unknown-unknown --toolchain nightly
     exit_if_error "Failed to add wasm target"
   fi
 }
@@ -225,6 +227,10 @@ handle_exec() {
 
   case "$cmd" in
     start)
+      if pgrep -u benchbot &>/dev/null; then
+        exit_with_error "the $benchbot_user user is already running a process"
+      fi
+
       if [ -e "$exec_log_file" ]; then
         local start_from_line="$(wc -l "$exec_log_file" | cut -d ' ' -f1)"
         exit_if_error "Failed to count the lines in $exec_log_file"
@@ -234,12 +240,23 @@ handle_exec() {
         unset start_from_line
       fi
 
-      $as_benchbot tmux new-session -d "
-        . ~/.cargo/env &&
-        cd \"$install_location\" &&
-        yarn &&
-        LOG_FORMAT=json LOG_LEVEL_IN_STRING=true LOG_LEVEL=info yarn start 2>&1 1>>\"$exec_log_file\"
-      "
+      unset env_vars
+
+      case "${1:-}" in
+        debug)
+          local env_vars="DEBUG=true"
+        ;;
+      esac
+
+      sudo ionice -c 1 -n 0 sudo nice -n -19 sudo -u $benchbot_user \
+        tmux new-session -d bash -c "
+          . ~/.cargo/env &&
+          cd \"$install_location\" &&
+          git config --local user.name 'Parity Bot' &&
+          git config --local user.email admin@parity.io &&
+          yarn &&
+          ${env_vars:-} yarn start 2>&1 | tee -a \"$exec_log_file\"
+        "
       exit_if_error "Failed to create tmux session for user $benchbot_user"
 
       echo -e "\nNote: the command will still be running after quitting this terminal. Use \"run stop\" for stopping it.\n"
@@ -280,7 +297,7 @@ start_follow_log_file() {
   local start_from_line="$(wc -l "$exec_log_file" | cut -d ' ' -f1)"
   exit_if_error "Failed to count the lines in $exec_log_file"
   start_from_line=$(( start_from_line + 1 ))
-  tail "--lines=+$start_from_line" -f "$exec_log_file" &
+  tail "--lines=+$start_from_line" -f "$exec_log_file" | awk '{ print "bb: " $0 }' &
   follow_log_file_tail_pid=$?
 }
 
@@ -394,10 +411,10 @@ handle_monitor() {
 
       exit_if_error "Failed to create service file at $monitor_service_file"
 
-      if [ -e "$exec_log_file" ]; then
+      if [ -e "$exec_log_file" ] || [ -e "$exec_log_dir_parent" ]; then
         sudo systemctl enable --now "$monitor_service"
       else
-        log "Start the service later with \"run monitor enable --now\""
+        log "The service \"$monitor_service\" was not activated (is the bot cloned at \"$install_location\"?). Start it later with with \"run monitor enable --now\"."
       fi
     ;;
     uninstall)
@@ -441,13 +458,14 @@ main() {
         log_error "Ref needs to be supplied"
         print_help_and_exit 1
       fi
+      shift
 
       handle_exec stop
 
       $as_benchbot bash -c "'${BASH_SOURCE[0]}' install_ref '$ref'"
       exit_if_error "Failed to install ref '$ref'"
 
-      $as_benchbot bash -c "'${BASH_SOURCE[0]}' start"
+      bash -c "'${BASH_SOURCE[0]}' start $@"
       exit_if_error "Failed to start"
     ;;
     monitor)
@@ -465,6 +483,7 @@ main() {
     ;;
     bootstrap)
       create_bot_user
+      exit_if_error "Failed to create user $benchbot_user"
 
       $as_benchbot bash -c "'${BASH_SOURCE[0]}' install_deps"
       exit_if_error "Failed to install dependencies"
@@ -473,6 +492,7 @@ main() {
       exit_if_error "Failed to install repository"
 
       handle_monitor install
+      exit_if_error "Failed to install and enable monitoring service"
     ;;
     help)
       print_help_and_exit 0


### PR DESCRIPTION
- Run the processes with priority
- Set stable as the default toolchain
- Improve `run` script
- Add more documentation
- Introduce `DEBUG` mode for figuring out issues with less friction.

After this PR lands:

- We should be seeing a decrease in the benchmark timings accross the board since processes are ran with priority. Examples:
   - https://github.com/paritytech/substrate/pull/9669/commits/3e8d819cd89efa24837584366f258f129c884e80
   - https://github.com/paritytech/substrate/pull/9507/commits/8da3202ab865f5d47f0f5b3e02af92a738ffc046
  - https://github.com/paritytech/substrate/pull/9675/commits/cb643f71961a62a37095d54f4afdc4162a6a199b
- The initial message will inform the active toolchain used for the benchmark.

closes #50 