### PR TITLE
Have asynchronous execution so that the bot stays responsive for new requests while executing commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .env
 git
 log.txt
+runner_output.txt

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@octokit/auth-app": "^3.5.3",
     "async-mutex": "^0.3.1",
     "probot": "^12.1.0",
-    "shelljs": "^0.8.4",
     "smee-client": "^1.2.2"
   },
   "devDependencies": {

--- a/runner.js
+++ b/runner.js
@@ -1,0 +1,70 @@
+const cp = require("child_process")
+const fs = require("fs")
+const path = require("path")
+const promisify = require("util").promisify
+
+const writeFileAsync = promisify(fs.writeFile)
+const readFileAsync = promisify(fs.readFile)
+const unlinkAsync = promisify(fs.unlink)
+const execFileAsync = promisify(cp.execFile)
+
+const runnerOutput = path.join(__dirname, "runner_stdout.txt")
+
+class Runner {
+  constructor(app) {
+    this.app = app
+    this.log = app.log
+  }
+
+  async run() {
+    let stdout = "",
+      stderr = "",
+      error = true
+
+    try {
+      if (title) {
+        app.log({ title, msg: `Running task on directory ${process.cwd()}` })
+      }
+
+      await writeFileAsync(runnerOutput, "")
+
+      // We the command is ran asynchronously so that the bot can still handle
+      // requests while it's executing. Previously we favored running the
+      // command synchronously so that there was less risk of having the Node.js
+      // process interfere or deprioritize the process' execution, but that it
+      // was observed that was unnecessary caution.
+      // Previously we've used cp.spawn for capturing the processes' streams
+      // but, again, having it execute directly in the shell reduces the
+      // likelihood of friction or overhead due to Node.js APIs.
+      // Since we should be redirecting the program's output streams to the
+      // systemd journal in the deployment, it's also relevant that we do not
+      // capture the process' streams here.
+      await execFileAsync(
+        "bash",
+        ["-c", `(${cmd}) 2>&1 | tee ${runnerOutput}`],
+        { stdio: "ignore" },
+      )
+
+      stdout = await readFileAsync(runnerOutput)
+      await unlinkAsync(runnerOutput)
+    } catch (err) {
+      try {
+        stderr = await readFileAsync(runnerOutput)
+      } catch (stderrReadError) {
+        app.log.fatal({
+          msg: "Failed to read stderr from command",
+          error: stderrReadError,
+        })
+      }
+      error = true
+      app.log.fatal({
+        msg: "Caught exception in command execution",
+        error: err,
+      })
+    }
+
+    return { stdout, stderr, error }
+  }
+}
+
+module.exports = { Runner }


### PR DESCRIPTION
In https://github.com/paritytech/polkadot/pull/3862 we saw the bot not being responsive. Likely that happened because a benchmark was being executed in the meantime and, since we're executing them synchronously, the main thread becomes blocked until the command is finished, therefore the bot is not able to respond to new requests.

https://github.com/paritytech/bench-bot/blob/992a8af4c5bf72ee5e08bcd109dfa5a0e37f16a0/bench.js#L37

We do not want to block the main thread but instead stay responsive and queue new requests if a benchmark is currently being executed.

At the moment bench-bot is using shelljs for executing commands, which performs fine in the synchronous case, although its asynchronous execution model is not what we want because it does not provide a built-in way of capturing the streams when the command finishes.

In this PR:
 
- Remove shell.js in favor of internal Runner abstraction
- Runner executes commands asynchronously so that the app stays responsive

Word of caution: we've faced issues related to overhead in the past (#47) although it's still inconclusive if asynchronous execution mattered for those cases. We should run the benchmarks after this branch is deployed and assure this change does not affect the measurements. If asynchronous execution does matter for those metrics, this implementation and the app's setup itself will have to be redesigned.