### PR TITLE
Add Rococo polkadot runtime benchmark config

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -297,6 +297,25 @@ var PolkadotRuntimeBenchmarkConfigs = {
       "--output=./runtime/westend/src/weights/{output_file}",
     ].join(" "),
   },
+	rococo: {
+		title: "Runtime Rococo Pallet",
+		benchCommand: [
+			"cargo run --quiet --release",
+			"--features=runtime-benchmarks",
+			"--",
+			"benchmark",
+			"--chain=rococo-dev",
+			"--steps=50",
+			"--repeat=20",
+			"--pallet={pallet_name}",
+			'--extrinsic="*"',
+			"--execution=wasm",
+			"--wasm-execution=compiled",
+			"--heap-pages=4096",
+			"--header=./file_header.txt",
+			"--output=./runtime/rococo/src/weights/{output_file}",
+		].join(" "),
+	},
   custom: {
     title: "Runtime Custom",
     benchCommand:


### PR DESCRIPTION
This PR adds a config to benchmark pallets for the rococo runtime. This should prevent us from having to use the more tedious custom benchmark command, like here https://github.com/paritytech/polkadot/pull/3914#issuecomment-926004905

TODO
- [ ] figure out how to test