### PR TITLE
Only restart the app after the current event finishes

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -8,8 +8,6 @@ function errorResult(message, error) {
 
 let cwd = process.cwd()
 
-const Mutex = require("async-mutex").Mutex
-const mutex = new Mutex()
 var shell = require("shelljs")
 
 var libCollector = require("./collector")
@@ -135,43 +133,42 @@ const prepareBranch = async function (
   if (error) return errorResult(stderr)
 }
 
-function benchBranch(app, config) {
+async function benchBranch(app, config) {
   app.log("Waiting our turn to run benchBranch...")
 
-  return mutex.runExclusive(async function () {
-    try {
-      if (config.repo != "substrate") {
-        return errorResult("Node benchmarks only available on Substrate.")
-      }
-
-      var id = config.id
-      var benchConfig = BenchConfigs[id]
-      if (!benchConfig) {
-        return errorResult(`Bench configuration for "${id}" was not found`)
-      }
-
-      const collector = new libCollector.Collector()
-      var benchContext = new BenchContext(app, config)
-      var { title, benchCommand } = benchConfig
-      app.log(`Started benchmark "${title}."`)
-
-      var error = await prepareBranch(config, { benchContext })
-      if (error) return error
-
-      var { stderr, error, stdout } = benchContext.runTask(
-        benchCommand,
-        `Benching branch ${config.branch}...`,
-      )
-      if (error) return errorResult(stderr)
-
-      await collector.CollectBranchCustomRunner(stdout)
-      let output = await collector.Report()
-
-      return { title, output, extraInfo: "", benchCommand }
-    } catch (error) {
-      return errorResult("Caught exception in benchBranch", error)
+  try {
+    if (config.repo != "substrate") {
+      return errorResult("Node benchmarks only available on Substrate.")
     }
-  })
+
+    var id = config.id
+    var benchConfig = BenchConfigs[id]
+    if (!benchConfig) {
+      return errorResult(`Bench configuration for "${id}" was not found`)
+    }
+
+    const collector = new libCollector.Collector()
+    var benchContext = new BenchContext(app, config)
+    var { title, benchCommand } = benchConfig
+    app.log(`Started benchmark "${title}."`)
+
+    var error = await prepareBranch(config, { benchContext })
+    if (error) return error
+
+    var { stderr, error, stdout } = benchContext.runTask(
+      benchCommand,
+      `Benching branch ${config.branch}...`,
+    )
+    if (error) return errorResult(stderr)
+
+    await collector.CollectBranchCustomRunner(stdout)
+    let output = await collector.Report()
+
+    return { title, output, extraInfo: "", benchCommand }
+  } catch (error) {
+    return errorResult("Caught exception in benchBranch", error)
+  }
+
 }
 
 var SubstrateRuntimeBenchmarkConfigs = {
@@ -444,168 +441,163 @@ function checkAllowedCharacters(command) {
   return true
 }
 
-function benchmarkRuntime(app, config) {
+async function benchmarkRuntime(app, config) {
   app.log("Waiting our turn to run benchmarkRuntime...")
 
-  return mutex.runExclusive(async function () {
-    try {
-      if (config.extra.split(" ").length < 2) {
-        return errorResult(`Incomplete command.`)
-      }
+  try {
+    if (config.extra.split(" ").length < 2) {
+      return errorResult(`Incomplete command.`)
+    }
 
-      let command = config.extra.split(" ")[0]
+    let command = config.extra.split(" ")[0]
 
-      var benchConfig
-      if (config.repo == "substrate" && config.id == "runtime") {
-        benchConfig = SubstrateRuntimeBenchmarkConfigs[command]
-      } else if (config.repo == "polkadot" && config.id == "runtime") {
-        benchConfig = PolkadotRuntimeBenchmarkConfigs[command]
-      } else if (config.repo == "polkadot" && config.id == "xcm") {
-        benchConfig = PolkadotXcmBenchmarkConfigs[command]
-      } else {
-        return errorResult(
-          `${config.repo} repo with ${config.id} is not supported.`,
-        )
-      }
-
-      var extra = config.extra.split(" ").slice(1).join(" ").trim()
-
-      if (!checkAllowedCharacters(extra)) {
-        return errorResult(`Not allowed to use #&|; in the command!`)
-      }
-
-      // Append extra flags to the end of the command
-      let benchCommand = benchConfig.benchCommand
-      if (command == "custom") {
-        // extra here should just be raw arguments to add to the command
-        benchCommand += " " + extra
-      } else {
-        // extra here should be the name of a pallet
-        benchCommand = benchCommand.replace("{pallet_name}", extra)
-        // custom output file name so that pallets with path don't cause issues
-        let outputFile = extra.includes("::")
-          ? extra.replace("::", "_") + ".rs"
-          : ""
-        benchCommand = benchCommand.replace("{output_file}", outputFile)
-        // pallet folder should be just the name of the pallet, without the leading
-        // "pallet_" or "frame_", then separated with "-"
-        let palletFolder = extra.split("_").slice(1).join("-").trim()
-        benchCommand = benchCommand.replace("{pallet_folder}", palletFolder)
-      }
-
-      let missing = checkRuntimeBenchmarkCommand(benchCommand)
-      if (missing.length > 0) {
-        return errorResult(`Missing required flags: ${missing.toString()}`)
-      }
-
-      var benchContext = new BenchContext(app, config)
-      var { title } = benchConfig
-      app.log(
-        `Started ${config.id} benchmark "${title}." (command: ${benchCommand})`,
+    var benchConfig
+    if (config.repo == "substrate" && config.id == "runtime") {
+      benchConfig = SubstrateRuntimeBenchmarkConfigs[command]
+    } else if (config.repo == "polkadot" && config.id == "runtime") {
+      benchConfig = PolkadotRuntimeBenchmarkConfigs[command]
+    } else if (config.repo == "polkadot" && config.id == "xcm") {
+      benchConfig = PolkadotXcmBenchmarkConfigs[command]
+    } else {
+      return errorResult(
+        `${config.repo} repo with ${config.id} is not supported.`,
       )
+    }
 
-      var error = await prepareBranch(config, { benchContext })
-      if (error) return error
+    var extra = config.extra.split(" ").slice(1).join(" ").trim()
 
-      const outputFile = benchCommand.match(/--output(?:=|\s+)(".+?"|\S+)/)[1]
-      var { stdout, stderr } = benchContext.runTask(
-        benchCommand,
-        `Running for branch ${config.branch}, ${outputFile ? `outputFile: ${outputFile}` : ""
-        }: ${benchCommand}`,
-      )
-      let extraInfo = ""
+    if (!checkAllowedCharacters(extra)) {
+      return errorResult(`Not allowed to use #&|; in the command!`)
+    }
 
-      var { stdout: gitStatus, stderr: gitStatusError } =
-        benchContext.runTask("git status --short")
-      app.log(`Git status after execution: ${gitStatus || gitStatusError}`)
+    // Append extra flags to the end of the command
+    let benchCommand = benchConfig.benchCommand
+    if (command == "custom") {
+      // extra here should just be raw arguments to add to the command
+      benchCommand += " " + extra
+    } else {
+      // extra here should be the name of a pallet
+      benchCommand = benchCommand.replace("{pallet_name}", extra)
+      // custom output file name so that pallets with path don't cause issues
+      let outputFile = extra.includes("::")
+        ? extra.replace("::", "_") + ".rs"
+        : ""
+      benchCommand = benchCommand.replace("{output_file}", outputFile)
+      // pallet folder should be just the name of the pallet, without the leading
+      // "pallet_" or "frame_", then separated with "-"
+      let palletFolder = extra.split("_").slice(1).join("-").trim()
+      benchCommand = benchCommand.replace("{pallet_folder}", palletFolder)
+    }
 
-      if (outputFile) {
-        if (process.env.DEBUG) {
-          app.log({
-            context: "Output file",
-            msg: fs.readFileSync(outputFile).toString(),
-          })
-        } else {
-          try {
+    let missing = checkRuntimeBenchmarkCommand(benchCommand)
+    if (missing.length > 0) {
+      return errorResult(`Missing required flags: ${missing.toString()}`)
+    }
+
+    var benchContext = new BenchContext(app, config)
+    var { title } = benchConfig
+    app.log(
+      `Started ${config.id} benchmark "${title}." (command: ${benchCommand})`,
+    )
+
+    var error = await prepareBranch(config, { benchContext })
+    if (error) return error
+
+    const outputFile = benchCommand.match(/--output(?:=|\s+)(".+?"|\S+)/)[1]
+    var { stdout, stderr } = benchContext.runTask(
+      benchCommand,
+      `Running for branch ${config.branch}, ${outputFile ? `outputFile: ${outputFile}` : ""
+      }: ${benchCommand}`,
+    )
+    let extraInfo = ""
+
+    var { stdout: gitStatus, stderr: gitStatusError } =
+      benchContext.runTask("git status --short")
+    app.log(`Git status after execution: ${gitStatus || gitStatusError}`)
+
+    if (outputFile) {
+      if (process.env.DEBUG) {
+        app.log({
+          context: "Output file",
+          msg: fs.readFileSync(outputFile).toString(),
+        })
+      } else {
+        try {
+          var last = benchContext.runTask(
+            `git add ${outputFile} && git commit -m "${benchCommand}"`,
+          )
+          if (last.error) {
+            extraInfo = `ERROR: Unable to commit file ${outputFile}`
+            config.logFatal({
+              msg: extraInfo,
+              stdout: last.stdout,
+              stderr: last.stderr,
+            })
+          } else {
+            const target = `${config.contributor}/${config.repo}`
+            const { url, token } = await config.getPushDomain()
             var last = benchContext.runTask(
-              `git add ${outputFile} && git commit -m "${benchCommand}"`,
+              `git remote set-url pr ${url}/${target}.git && git push pr HEAD`,
+              `Pushing ${outputFile} to ${config.branch}`,
             )
             if (last.error) {
-              extraInfo = `ERROR: Unable to commit file ${outputFile}`
+              extraInfo = `ERROR: Unable to push ${outputFile}`
               config.logFatal({
                 msg: extraInfo,
                 stdout: last.stdout,
                 stderr: last.stderr,
               })
-            } else {
-              const target = `${config.contributor}/${config.repo}`
-              const { url, token } = await config.getPushDomain()
-              var last = benchContext.runTask(
-                `git remote set-url pr ${url}/${target}.git && git push pr HEAD`,
-                `Pushing ${outputFile} to ${config.branch}`,
-              )
-              if (last.error) {
-                extraInfo = `ERROR: Unable to push ${outputFile}`
-                config.logFatal({
-                  msg: extraInfo,
-                  stdout: last.stdout,
-                  stderr: last.stderr,
-                })
-              }
             }
-          } catch (error) {
-            extraInfo =
-              "NOTE: Caught exception while trying to push commits to the repository"
-            config.logFatal({ msg: extraInfo, error })
           }
+        } catch (error) {
+          extraInfo =
+            "NOTE: Caught exception while trying to push commits to the repository"
+          config.logFatal({ msg: extraInfo, error })
         }
       }
-
-      return {
-        title,
-        output: stdout ? stdout : stderr,
-        extraInfo,
-        benchCommand,
-      }
-    } catch (error) {
-      return errorResult("Caught exception in benchmarkRuntime", error)
     }
-  })
+
+    return {
+      title,
+      output: stdout ? stdout : stderr,
+      extraInfo,
+      benchCommand,
+    }
+  } catch (error) {
+    return errorResult("Caught exception in benchmarkRuntime", error)
+  }
 }
 
-function benchRustup(app, config) {
+async function benchRustup(app, config) {
   app.log("Waiting our turn to run benchRustup...")
 
-  return mutex.runExclusive(async function () {
-    try {
-
-      // right now only `rustup update` is supported.
-      if (config.extra != "update") {
-        return errorResult(`Invalid "rustup" command. Only "update" is supported.`)
-      }
-
-      const collector = new libCollector.Collector()
-      var benchContext = new BenchContext(app, config)
-
-      let benchCommand = "rustup update";
-      let title = "Rustup Update";
-
-      var { stderr, error, stdout } = benchContext.runTask(
-        benchCommand,
-        `Executing "rustup update"...`,
-      )
-      if (error) return errorResult(stderr)
-
-      return {
-        title,
-        output: stdout ? stdout : stderr,
-        extraInfo: "",
-        benchCommand
-      }
-    } catch (error) {
-      return errorResult("Caught exception in benchRustup", error)
+  try {
+    // right now only `rustup update` is supported.
+    if (config.extra != "update") {
+      return errorResult(`Invalid "rustup" command. Only "update" is supported.`)
     }
-  })
+
+    const collector = new libCollector.Collector()
+    var benchContext = new BenchContext(app, config)
+
+    let benchCommand = "rustup update";
+    let title = "Rustup Update";
+
+    var { stderr, error, stdout } = benchContext.runTask(
+      benchCommand,
+      `Executing "rustup update"...`,
+    )
+    if (error) return errorResult(stderr)
+
+    return {
+      title,
+      output: stdout ? stdout : stderr,
+      extraInfo: "",
+      benchCommand
+    }
+  } catch (error) {
+    return errorResult("Caught exception in benchRustup", error)
+  }
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -214,20 +214,20 @@ module.exports = (app) => {
         let { title, output, extraInfo, benchCommand } = report
 
         const bodyPrefix = `
-  Benchmark **${title}** for branch "${branch}" with command ${benchCommand}
+Benchmark **${title}** for branch "${branch}" with command ${benchCommand}
 
-  Toolchain: ${toolchain}
+Toolchain: ${toolchain}
 
-  <details>
-  <summary>Results</summary>
+<details>
+<summary>Results</summary>
 
-  \`\`\`
+\`\`\`
   `.trim()
 
         const bodySuffix = `
-  \`\`\`
+\`\`\`
 
-  </details>
+</details>
   `.trim()
 
         const padding = 16
@@ -243,11 +243,11 @@ module.exports = (app) => {
         }
 
         const body = `
-  ${bodyPrefix}
-  ${output}
-  ${bodySuffix}
+${bodyPrefix}
+${output}
+${bodySuffix}
 
-  ${extraInfo}
+${extraInfo}
   `.trim()
 
         await context.octokit.issues.updateComment({

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const { createAppAuth } = require("@octokit/auth-app")
 const assert = require("assert")
 const fs = require("fs")
 const shell = require("shelljs")
+const Mutex = require("async-mutex").Mutex
 
 var { benchBranch, benchmarkRuntime, benchRustup } = require("./bench")
 
@@ -10,6 +11,8 @@ const githubCommentLimitTruncateMessage = "<truncated>..."
 
 let isTerminating = false
 let logFatal = undefined
+
+let pendingPayloadCount = 0
 
 for (const event of ["uncaughtException", "unhandledRejection"]) {
   process.on(event, function (error, origin) {
@@ -30,6 +33,7 @@ for (const event of ["uncaughtException", "unhandledRejection"]) {
   })
 }
 
+const mutex = new Mutex()
 module.exports = (app) => {
   if (process.env.DEBUG) {
     app.log("Running in debug mode")
@@ -44,16 +48,27 @@ module.exports = (app) => {
   // FIXME: This is suboptimal and we should not have to stop the application in
   // case of errors
   // The server will automatically restarted on failures in ./run
+  const exitWhenFree = async function() {
+    const isFree = await mutex.runExclusive(function () {
+      return pendingPayloadCount === 0
+    })
+    if (isFree) {
+      process.exit(1)
+    } else {
+      await exitWhenFree()
+    }
+  }
+  const logThenExit = function(log) {
+    return async function(...args) {
+      log(...args)
+      // only exit the application after the current events have been processed
+      await exitWhenFree()
+    }
+  }
   const logError = app.log.error
-  app.log.error = function(...args) {
-    logError(...args)
-    process.exit(1)
-  }
+  app.log.error = logThenExit(logError)
   logFatal = app.log.fatal
-  app.log.fatal = function(...args) {
-    logFatal(...args)
-    process.exit(1)
-  }
+  app.log.fatal = logThenExit(logFatal)
 
   const baseBranch = process.env.BASE_BRANCH || "master"
   app.log.debug(`base branch: ${baseBranch}`)
@@ -79,179 +94,183 @@ module.exports = (app) => {
   })
 
   app.on("issue_comment", async (context) => {
-    let commentText = context.payload.comment.body
-    if (
-      !context.payload.issue.hasOwnProperty("pull_request") ||
-      context.payload.action !== "created" ||
-      !commentText.startsWith("/bench")
-    ) {
-      return
-    }
-
-    try {
-      const installationId = (context.payload.installation || {}).id
-      if (!installationId) {
-        await context.octokit.issues.createComment(
-          context.issue({
-            body: `Error: Installation id was missing from webhook payload`,
-          }),
-        )
+    pendingPayloadCount++
+    await mutex.runExclusive(async function() {
+      let commentText = context.payload.comment.body
+      if (
+        !context.payload.issue.hasOwnProperty("pull_request") ||
+        context.payload.action !== "created" ||
+        !commentText.startsWith("/bench")
+      ) {
         return
       }
 
-      const getPushDomain = async function () {
-        const token = (
-          await authInstallation({ type: "installation", installationId })
-        ).token
-
-        const url = `https://x-access-token:${token}@github.com`
-        return { url, token }
-      }
-
-      const repo = context.payload.repository.name
-      const owner = context.payload.repository.owner.login
-      const pull_number = context.payload.issue.number
-
-      // Capture `<action>` in `/bench <action> <extra>`
-      let action = commentText.split(" ").splice(1, 1).join(" ").trim()
-      // Capture all `<extra>` text in `/bench <action> <extra>`
-      let extra = commentText.split(" ").splice(2).join(" ").trim()
-
-      let pr = await context.octokit.pulls.get({ owner, repo, pull_number })
-      const contributor = pr.data.head.user.login
-      const branch = pr.data.head.ref
-      app.log.debug(`branch: ${branch}`)
-
-      var { stdout: toolchain, code: toolchainError } = shell.exec(
-        "rustup show active-toolchain --verbose",
-        { silent: false },
-      )
-      if (toolchainError) {
-        await context.octokit.issues.createComment(
-          context.issue({
-            body: "ERROR: Failed to query the currently active Rust toolchain",
-          }),
-        )
-        return
-      } else {
-        toolchain = toolchain.trim()
-      }
-
-      const initialInfo = `Starting benchmark for branch: ${branch} (vs ${baseBranch})\n\nToolchain: \n${toolchain}\n\n Comment will be updated.`
-      let comment_id = undefined
-      if (process.env.DEBUG) {
-        app.log(initialInfo)
-      } else {
-        const issueComment = context.issue({ body: initialInfo })
-        const issue_comment = await context.octokit.issues.createComment(
-          issueComment,
-        )
-        comment_id = issue_comment.data.id
-      }
-
-      let config = {
-        owner,
-        contributor,
-        repo,
-        branch,
-        baseBranch,
-        id: action,
-        extra,
-        getPushDomain,
-        logFatal
-      }
-
-      let report
-      if (action == "runtime" || action == "xcm") {
-        report = await benchmarkRuntime(app, config)
-      } else if (action == "rustup") {
-        report = await benchRustup(app, config)
-      } else {
-        report = await benchBranch(app, config)
-      }
-      if (process.env.DEBUG) {
-        console.log(report)
-        return
-      }
-
-      if (report.isError) {
-        logError(report.message)
-
-        if (report.error) {
-          logError(report.error)
+      try {
+        const installationId = (context.payload.installation || {}).id
+        if (!installationId) {
+          await context.octokit.issues.createComment(
+            context.issue({
+              body: `Error: Installation id was missing from webhook payload`,
+            }),
+          )
+          return
         }
 
-        const output = `${report.message}${report.error ? `: ${report.error.toString()}` : ""
-          }`
+        const getPushDomain = async function () {
+          const token = (
+            await authInstallation({ type: "installation", installationId })
+          ).token
+
+          const url = `https://x-access-token:${token}@github.com`
+          return { url, token }
+        }
+
+        const repo = context.payload.repository.name
+        const owner = context.payload.repository.owner.login
+        const pull_number = context.payload.issue.number
+
+        // Capture `<action>` in `/bench <action> <extra>`
+        let action = commentText.split(" ").splice(1, 1).join(" ").trim()
+        // Capture all `<extra>` text in `/bench <action> <extra>`
+        let extra = commentText.split(" ").splice(2).join(" ").trim()
+
+        let pr = await context.octokit.pulls.get({ owner, repo, pull_number })
+        const contributor = pr.data.head.user.login
+        const branch = pr.data.head.ref
+        app.log.debug(`branch: ${branch}`)
+
+        var { stdout: toolchain, code: toolchainError } = shell.exec(
+          "rustup show active-toolchain --verbose",
+          { silent: false },
+        )
+        if (toolchainError) {
+          await context.octokit.issues.createComment(
+            context.issue({
+              body: "ERROR: Failed to query the currently active Rust toolchain",
+            }),
+          )
+          return
+        } else {
+          toolchain = toolchain.trim()
+        }
+
+        const initialInfo = `Starting benchmark for branch: ${branch} (vs ${baseBranch})\n\nToolchain: \n${toolchain}\n\n Comment will be updated.`
+        let comment_id = undefined
+        if (process.env.DEBUG) {
+          app.log(initialInfo)
+        } else {
+          const issueComment = context.issue({ body: initialInfo })
+          const issue_comment = await context.octokit.issues.createComment(
+            issueComment,
+          )
+          comment_id = issue_comment.data.id
+        }
+
+        let config = {
+          owner,
+          contributor,
+          repo,
+          branch,
+          baseBranch,
+          id: action,
+          extra,
+          getPushDomain,
+          logFatal
+        }
+
+        let report
+        if (action == "runtime" || action == "xcm") {
+          report = await benchmarkRuntime(app, config)
+        } else if (action == "rustup") {
+          report = await benchRustup(app, config)
+        } else {
+          report = await benchBranch(app, config)
+        }
+        if (process.env.DEBUG) {
+          console.log(report)
+          return
+        }
+
+        if (report.isError) {
+          logError(report.message)
+
+          if (report.error) {
+            logError(report.error)
+          }
+
+          const output = `${report.message}${report.error ? `: ${report.error.toString()}` : ""
+            }`
+
+          await context.octokit.issues.updateComment({
+            owner,
+            repo,
+            comment_id,
+            body: `Error running benchmark: **${branch}**\n\n<details><summary>stdout</summary>${output}</details>`,
+          })
+
+          return
+        }
+
+        let { title, output, extraInfo, benchCommand } = report
+
+        const bodyPrefix = `
+  Benchmark **${title}** for branch "${branch}" with command ${benchCommand}
+
+  Toolchain: ${toolchain}
+
+  <details>
+  <summary>Results</summary>
+
+  \`\`\`
+  `.trim()
+
+        const bodySuffix = `
+  \`\`\`
+
+  </details>
+  `.trim()
+
+        const padding = 16
+        const formattingLength =
+          bodyPrefix.length + bodySuffix.length + extraInfo.length + padding
+        const length = formattingLength + output.length
+        if (length >= githubCommentLimitLength) {
+          output = `${output.slice(
+            0,
+            githubCommentLimitLength -
+            (githubCommentLimitTruncateMessage.length + formattingLength),
+          )}${githubCommentLimitTruncateMessage}`
+        }
+
+        const body = `
+  ${bodyPrefix}
+  ${output}
+  ${bodySuffix}
+
+  ${extraInfo}
+  `.trim()
 
         await context.octokit.issues.updateComment({
           owner,
           repo,
           comment_id,
-          body: `Error running benchmark: **${branch}**\n\n<details><summary>stdout</summary>${output}</details>`,
+          body,
         })
-
-        return
+      } catch (error) {
+        logFatal({
+          error,
+          repo,
+          owner,
+          pull_number,
+          msg: "Caught exception in issue_comment's handler",
+        })
+        await context.octokit.issues.createComment(
+          context.issue({
+            body: `Exception caught: \`${error.message}\`\n${error.stack}`,
+          }),
+        )
       }
-
-      let { title, output, extraInfo, benchCommand } = report
-
-      const bodyPrefix = `
-Benchmark **${title}** for branch "${branch}" with command ${benchCommand}
-
-Toolchain: ${toolchain}
-
-<details>
-<summary>Results</summary>
-
-\`\`\`
-`.trim()
-
-      const bodySuffix = `
-\`\`\`
-
-</details>
-`.trim()
-
-      const padding = 16
-      const formattingLength =
-        bodyPrefix.length + bodySuffix.length + extraInfo.length + padding
-      const length = formattingLength + output.length
-      if (length >= githubCommentLimitLength) {
-        output = `${output.slice(
-          0,
-          githubCommentLimitLength -
-          (githubCommentLimitTruncateMessage.length + formattingLength),
-        )}${githubCommentLimitTruncateMessage}`
-      }
-
-      const body = `
-${bodyPrefix}
-${output}
-${bodySuffix}
-
-${extraInfo}
-`.trim()
-
-      await context.octokit.issues.updateComment({
-        owner,
-        repo,
-        comment_id,
-        body,
-      })
-    } catch (error) {
-      logFatal({
-        error,
-        repo,
-        owner,
-        pull_number,
-        msg: "Caught exception in issue_comment's handler",
-      })
-      await context.octokit.issues.createComment(
-        context.issue({
-          body: `Exception caught: \`${error.message}\`\n${error.stack}`,
-        }),
-      )
-    }
+    })
+    pendingPayloadCount--
   })
 }

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = (app) => {
   // (https://github.com/paritytech/bench-bot/issues/83#issuecomment-1024283664)
   // FIXME: This is suboptimal and we should not have to stop the application in
   // case of errors
-  // The server will automatically restarted on failures in ./run
+  // The server will automatically restarted upon exit in ./run
   const exitWhenFree = async function() {
     const isFree = await mutex.runExclusive(function () {
       return pendingPayloadCount === 0

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ module.exports = (app) => {
   // FIXME: This is suboptimal and we should not have to stop the application in
   // case of errors
   // The server will automatically restarted upon exit in ./run
+  let isWaitingForExitingWhenFree = false
   const exitWhenFree = async function() {
     const isFree = await mutex.runExclusive(function () {
       return pendingPayloadCount === 0
@@ -62,6 +63,11 @@ module.exports = (app) => {
     return async function(...args) {
       log(...args)
       // only exit the application after the current events have been processed
+      // we only need to register this action once since exitWhenFree calls itself
+      if (isWaitingForExitingWhenFree) {
+        return
+      }
+      isWaitingForExitingWhenFree = true
       await exitWhenFree()
     }
   }


### PR DESCRIPTION
Move mutex to the event handlers so that the app is only restarted (#84) when the current events have been processed. This avoids having some relevant work being stopped off halfway due to some unrelated server failure.

Not having this might not be a problem at the moment because we're supposed to be blocking the application while some event is being executed (#68). In any case it's better to have it.