### PR TITLE
Verify installation id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 *.pem
 .env
 git
+log.txt

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Create a `.env` file in the root with the following:
 
 ```
 APP_ID=<App id from Github App Settings>
+INSTALLATION_ID=<Installation id from Github Settings>
 BASE_BRANCH=<the default branch for merging into the PRs, e.g. master>
 CLIENT_ID=<Client ID from Github App Settings>
 CLIENT_SECRET=<Client ID from Github App Settings>
@@ -60,7 +61,7 @@ in the bot's directory.
 - `run {start,stop,restart}`: execute the relevant action for the bot.
 - `run update [ref]`: restart the bot with the branch or PR
   - For branch: `ssh user@remote '/home/benchbot/bench-bot/run update master'`
-  - For PR: `ssh user@remote '/home/benchbot/bench-bot/run update pull/number/head:branch'` 
+  - For PR: `ssh user@remote '/home/benchbot/bench-bot/run update pull/number/head:branch'`
     e.g. `pull/1/head:master`
 
 ### Monitoring Service commands

--- a/bench.js
+++ b/bench.js
@@ -400,7 +400,8 @@ function benchmarkRuntime(app, config) {
                   }
                 }
               } catch (error) {
-                extraInfo = `NOTE: Failed to push commits to repository: ${error.toString().replace(token, "{secret}", "g")}`
+                extraInfo = "NOTE: Caught exception while trying to push commits to the repository"
+                app.log.fatal({ msg: extraInfo, error })
               }
             }
           }

--- a/index.js
+++ b/index.js
@@ -42,6 +42,8 @@ module.exports = (app) => {
 
   const appId = parseInt(process.env.APP_ID)
   assert(appId)
+  const installationId = parseInt(process.env.INSTALLATION_ID);
+  assert(installationId);
 
   const clientId = process.env.CLIENT_ID
   assert(clientId)
@@ -100,8 +102,8 @@ module.exports = (app) => {
     }
 
     try {
-      const installationId = (context.payload.installation || {}).id
-      if (!installationId) {
+      const sourceInstallationId = (context.payload.installation || {}).id
+      if (!sourceInstallationId) {
         await context.octokit.issues.createComment(
           context.issue({
             body: `Error: Installation id was missing from webhook payload`,
@@ -109,6 +111,9 @@ module.exports = (app) => {
         )
         app.log.error("Installation id was missing from webhook payload");
         return
+      } else if (sourceInstallationId != installationId) {
+        console.log(`Warning: ignoring payload from irrelevant installation ${sourceInstallationId}`);
+        return;
       }
 
       const getPushDomain = async function () {

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ module.exports = app => {
     };
 
     // Max github body is 65536 characters... we are a little conservative.
-    report = report.substring(0, 65000)
+    report = report.substr(-65000)
 
     if (report.error) {
       app.log(`error: ${report.stderr}`)

--- a/run
+++ b/run
@@ -483,7 +483,6 @@ main() {
     ;;
     bootstrap)
       create_bot_user
-      exit_if_error "Failed to create user $benchbot_user"
 
       $as_benchbot bash -c "'${BASH_SOURCE[0]}' install_deps"
       exit_if_error "Failed to install dependencies"
@@ -492,7 +491,6 @@ main() {
       exit_if_error "Failed to install repository"
 
       handle_monitor install
-      exit_if_error "Failed to install and enable monitoring service"
     ;;
     help)
       print_help_and_exit 0


### PR DESCRIPTION
This PR requires `INSTALLATION_ID` to be in the environment and checks this against the `issue_comment` source. This should prevent any issues with the app being public.